### PR TITLE
Modernize plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ To get an even better integration, use Joda-Beans v1.5 or later and add the foll
               <execution>
                 <phase>generate-sources</phase>
                 <goals>
-                  <goal>generate</goal>
+                  <goal>generate-no-resolve</goal>
                 </goals>
                 <configuration>
                   <eclipse>true</eclipse>
@@ -175,10 +175,11 @@ To get an even better integration, use Joda-Beans v1.5 or later and add the foll
 ```
 
 This profile only activates when running in Eclipse IDE.
-It causes the `generate` goal to be executed using the special "eclipse=true" mode.
+It causes the `generate-no-resolve` goal to be executed using the special "eclipse=true" mode.
 This mode means that when a bean is edited, the Joda-Beans source generator is triggered,
 and the file recompiled. Note that the processing in Eclipse takes a few seconds to refresh properly.
-This has been tested with Eclipse Luna, Mars and Neon.
+
+(`generate-no-resolve` is a special mode from v1.2.0 that avoids resolving the classpath, which can give Eclipse problems)
 
 
 #### Joda-Beans version

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This goal has the following optional configuration items:
 - `indent` - as per the command line, the amount of indentation used,
 either the word "tab", or a number, such as "2" or "4". Default is "4". Property is `${joda.beans.indent}`.
 - `prefix` - as per the command line, the prefix used by fields. Default is "". Property is `${joda.beans.prefix}`.
-- `config` - as per the command line, the config to use, "jdk6" pr "guava". Default is "guava". Property is `${joda.beans.config}`.
+- `config` - as per the command line, the config to use, "jdk" or "guava". Default is "guava". Property is `${joda.beans.config}`.
 - `verbose` - as per the command line, a number from "0" (quiet) to "3" (verbose). Property is `${joda.beans.verbose}`.
 - `stopOnError` - whether the build should continue when an error is found. Default is "true". Property is `${joda.beans.stopOnError}`.
 - `skip` - skips the plugin

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>joda-beans-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
   <name>Joda-Beans Maven plugin</name>
-  <version>1.1</version>
+  <version>1.2.0-SNAPSHOT</version>
   <description>Maven plugin for Joda-Beans</description>
   <url>https://github.com/JodaOrg/joda-beans-maven-plugin</url>
 
@@ -257,24 +257,29 @@
   <!-- ==================================================================== -->
   <dependencies>
     <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.0.5</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.0.5</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>2.2.1</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>2.2.1</version>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.sonatype.plexus</groupId>
@@ -295,10 +300,13 @@
     <dependency>
       <groupId>com.tngtech.java</groupId>
       <artifactId>junit-dataprovider</artifactId>
-      <version>1.10.0</version>
+      <version>1.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <prerequisites>
+    <maven>${maven.version}</maven>
+  </prerequisites>
 
   <!-- ==================================================================== -->
   <distributionManagement>
@@ -382,28 +390,29 @@
   <!-- ==================================================================== -->
   <properties>
     <!-- Plugin version numbers -->
-    <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
+    <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
     <maven-changes-plugin.version>2.12.1</maven-changes-plugin.version>
     <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
-    <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
-    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-    <maven-dependency-plugin.version>3.0.0</maven-dependency-plugin.version>
+    <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+    <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-    <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-    <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
-    <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
-    <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
-    <maven-pmd-plugin.version>3.7</maven-pmd-plugin.version>
-    <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
+    <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+    <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
+    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <maven-jxr-plugin.version>3.0.0</maven-jxr-plugin.version>
+    <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
+    <maven-pmd-plugin.version>3.11.0</maven-pmd-plugin.version>
+    <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
     <maven-repository-plugin.version>3.0.2</maven-repository-plugin.version>
-    <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
-    <maven-site-plugin.version>3.6</maven-site-plugin.version>
+    <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+    <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-    <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
-    <maven-surefire-report-plugin.version>2.19.1</maven-surefire-report-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+    <maven-surefire-report-plugin.version>3.0.0-M3</maven-surefire-report-plugin.version>
     <maven-toolchains-plugin.version>1.1</maven-toolchains-plugin.version>
+    <maven.version>3.5.0</maven.version>
     <!-- Properties for maven-compiler-plugin -->
     <maven.compiler.compilerVersion>1.6</maven.compiler.compilerVersion>
     <maven.compiler.source>1.6</maven.compiler.source>

--- a/src/main/java/org/joda/beans/maven/AbstractJodaBeansGenerateMojo.java
+++ b/src/main/java/org/joda/beans/maven/AbstractJodaBeansGenerateMojo.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2013-present, Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.beans.maven;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.util.Scanner;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+/**
+ * Maven plugin for generating Joda-Beans.
+ */
+public abstract class AbstractJodaBeansGenerateMojo extends AbstractJodaBeansMojo {
+
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected void runTool(
+            Class<?> toolClass,
+            List<String> argsList,
+            BuildContext buildContext) throws MojoExecutionException, MojoFailureException {
+
+        // only match java files that have changed according to the build context
+        // this avoids processing when there is nothing to do
+        String[] changedSourceFiles = findFiles(buildContext, getSourceDir());
+        String[] changedTestFiles = findFiles(buildContext, getTestSourceDir());
+        int sourceFilesChanged = changedSourceFiles.length;
+        int testFilesChanged = changedTestFiles.length;
+
+        // if nothing to do then exit
+        if (sourceFilesChanged == 0 && testFilesChanged == 0) {
+            logInfo("No files changed");
+            return;
+        }
+        logDebug("Files changed: main=" + sourceFilesChanged + ", test=" + testFilesChanged);
+
+        logInfo("Joda-Bean generator started, directory: " + getSourceDir() +
+                (getTestSourceDir().length() == 0 ? "" : ", test directory: " + getTestSourceDir()));
+
+        // invoke main source
+        int changedFileCount = 0;
+        if (sourceFilesChanged > 0) {
+            if (sourceFilesChanged == 1) {
+                File file = new File(getSourceDir(), changedSourceFiles[0]);
+                argsList.add(file.toString());
+                logDebug("Single file: " + argsList.get(argsList.size() - 1));
+                changedFileCount += runToolHandleChanges(toolClass, argsList, file.getParentFile(), new File(getClassesDir()));
+            } else {
+                argsList.add(getSourceDir());
+                logDebug("All files: " + argsList.get(argsList.size() - 1));
+                changedFileCount += runToolHandleChanges(toolClass, argsList, new File(getSourceDir()), new File(getClassesDir()));
+            }
+        }
+        // optionally invoke test source
+        if (testFilesChanged > 0) {
+            if (testFilesChanged == 1) {
+                File file = new File(getSourceDir(), changedTestFiles[0]);
+                argsList.set(argsList.size() - 1, file.toString());
+                logDebug("Single test file: " + argsList.get(argsList.size() - 1));
+                changedFileCount += runToolHandleChanges(toolClass, argsList, file.getParentFile(), new File(getTestClassesDir()));
+            } else {
+                argsList.set(argsList.size() - 1, getTestSourceDir());
+                logDebug("All test files: " + argsList.get(argsList.size() - 1));
+                changedFileCount += runToolHandleChanges(toolClass, argsList, new File(getTestSourceDir()), new File(getTestClassesDir()));
+            }
+        }
+
+        logInfo("Joda-Bean generator completed, " + changedFileCount + " changed files");
+    }
+
+    // find Java files
+    private String[] findFiles(BuildContext buildContext, String dirStr) {
+        File dir = new File(dirStr);
+        if (dirStr.isEmpty() || !dir.exists()) {
+            return EMPTY_STRING_ARRAY;
+        }
+        Scanner scanner = buildContext.newScanner(dir);
+        scanner.setIncludes(new String[] {"**/*.java"});
+        scanner.scan();
+        String[] changedSourceFiles = scanner.getIncludedFiles();
+        return changedSourceFiles;
+    }
+
+}

--- a/src/main/java/org/joda/beans/maven/AbstractJodaBeansMojo.java
+++ b/src/main/java/org/joda/beans/maven/AbstractJodaBeansMojo.java
@@ -34,6 +34,8 @@ import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
@@ -52,66 +54,40 @@ public class AbstractJodaBeansMojo extends AbstractMojo {
     static final Pattern MESSAGE_PATTERN =
             Pattern.compile("Error in bean[:] (.*?)[,] Line[:] ([0-9]+)[,] Message[:] (.*)");
 
-    /**
-     * Skips the mojo.
-     * @parameter alias="skip" property="joda.beans.skip"
-     */
-    private boolean _skip;
-    /**
-     * @parameter default-value="${project.build.sourceDirectory}" property="joda.beans.source.dir"
-     * @required
-     * @readonly
-     */
-    private String sourceDir;
-    /**
-     * @parameter default-value="${project.build.outputDirectory}" property="joda.beans.classes.dir"
-     * @required
-     * @readonly
-     */
-    private String classesDir;
-    /**
-     * @parameter default-value="${project.build.testSourceDirectory}" property="joda.beans.test.source.dir"
-     * @required
-     * @readonly
-     */
-    private String testSourceDir;
-    /**
-     * @parameter default-value="${project.build.testOutputDirectory}" property="joda.beans.test.classes.dir"
-     * @required
-     * @readonly
-     */
-    private String testClassesDir;
-    /**
-     * @parameter alias="indent" property="joda.beans.indent"
-     */
+    @Parameter(alias = "skip", property = "joda.beans.skip", defaultValue = "false")
+    private boolean skip;
+
+    @Parameter(alias = "indent", property = "joda.beans.indent")
     private String indent;
-    /**
-     * @parameter alias="prefix" property="joda.beans.prefix"
-     */
+
+    @Parameter(alias = "prefix", property = "joda.beans.prefix")
     private String prefix;
-    /**
-     * @parameter alias="config" property="joda.beans.config"
-     */
+
+    @Parameter(alias = "config", property = "joda.beans.config")
     private String config;
-    /**
-     * @parameter alias="verbose" property="joda.beans.verbose"
-     */
+
+    @Parameter(alias = "verbose", property = "joda.beans.verbose")
     private Integer verbose;
-    /**
-     * @parameter alias="eclipse" property="joda.beans.eclipse"
-     */
+
+    @Parameter(alias = "eclipse", property = "joda.beans.eclipse", defaultValue = "false")
     private boolean eclipse;
-    /**
-     * The Maven project.
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
-    private MavenProject _project;
-    /**
-     * Better support for IDEs.
-     * @component
-     */
+
+    @Parameter(alias = "sourceDir", property = "joda.beans.source.dir", defaultValue = "${project.build.sourceDirectory}", required = true)
+    private String sourceDir;
+
+    @Parameter(alias = "classesDir", property = "joda.beans.classes.dir", defaultValue = "${project.build.outputDirectory}", required = true, readonly = true)
+    private String classesDir;
+
+    @Parameter(alias = "testSourceDir", property = "joda.beans.test.source.dir", defaultValue = "${project.build.testSourceDirectory}", required = true, readonly = true)
+    private String testSourceDir;
+
+    @Parameter(alias = "testClassesDir", property = "joda.beans.test.classes.dir", defaultValue = "${project.build.testOutputDirectory}", required = true, readonly = true)
+    private String testClassesDir;
+
+    @Parameter(alias = "project", defaultValue = "${project}", required = true, readonly = true)
+    private MavenProject project;
+
+    @Component
     private BuildContext buildContext;
 
     //-----------------------------------------------------------------------
@@ -159,7 +135,7 @@ public class AbstractJodaBeansMojo extends AbstractMojo {
      */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        if (_skip) {
+        if (skip) {
             return;
         }
         if (getSourceDir().length() == 0) {
@@ -421,10 +397,9 @@ public class AbstractJodaBeansMojo extends AbstractMojo {
      * @return the classpath, not null
      * @throws MojoExecutionException
      */
-    @SuppressWarnings("unchecked")
     private List<String> obtainClasspath() throws MojoExecutionException {
         try {
-            return _project.getCompileClasspathElements();
+            return project.getCompileClasspathElements();
         } catch (DependencyResolutionRequiredException ex) {
             throw new MojoExecutionException("Error obtaining dependencies", ex);
         }

--- a/src/main/java/org/joda/beans/maven/AbstractJodaBeansMojo.java
+++ b/src/main/java/org/joda/beans/maven/AbstractJodaBeansMojo.java
@@ -351,7 +351,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
     }
 
     // obtains the classloader from a set of file paths
-    private URLClassLoader obtainClassLoader() throws MojoExecutionException {
+    ClassLoader obtainClassLoader() throws MojoExecutionException {
         logDebug("Finding joda-beans in classpath");
         List<String> compileClasspath = obtainClasspath();
         Set<URL> classpathUrlSet = new HashSet<URL>();

--- a/src/main/java/org/joda/beans/maven/AbstractJodaBeansMojo.java
+++ b/src/main/java/org/joda/beans/maven/AbstractJodaBeansMojo.java
@@ -182,17 +182,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
         return argsList;
     }
 
-    /**
-     * Runs the tool.
-     * 
-     * @param toolClass  the tool class, not null
-     * @param argsList  the argument flags, not null
-     * @param sourceFilesChanged  whether the source files have changed
-     * @param testFilesChanged  whether the test files have changed
-     * @return the number of changes
-     * @throws MojoExecutionException if an error occurs
-     * @throws MojoFailureException if a failure occurs
-     */
+    // runs the tool
     abstract void runTool(Class<?> toolClass, List<String> argsList, BuildContext buildContext) throws MojoExecutionException, MojoFailureException;
 
     // remove any error markers leftover from the last run
@@ -230,6 +220,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
         }
     }
 
+    // invokes the generator by reflection
     private List<File> invoke(Class<?> toolClass, List<String> argsList) throws MojoExecutionException, MojoFailureException {
         long start = System.nanoTime();
         try {
@@ -248,6 +239,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
         }
     }
 
+    // finds the method to call by reflection
     private Method findCreateFromArgsMethod(Class<?> toolClass) throws MojoExecutionException {
         Method createFromArgsMethod = null;
         try {
@@ -258,6 +250,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
         return createFromArgsMethod;
     }
 
+    // finds the method to call by reflection
     private Method findProcessMethod(Class<?> toolClass) throws MojoExecutionException {
         Method processMethod = null;
         try {
@@ -274,6 +267,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
         return processMethod;
     }
 
+    // creates the generator by reflection
     private Object createBuilder(List<String> argsList, Method createFromArgsMethod) throws MojoExecutionException, MojoFailureException {
         String[] args = argsList.toArray(new String[argsList.size()]);
         try {
@@ -287,6 +281,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
         }
     }
 
+    // invokes the builder
     private int invokeBuilderCountChanges(Method processMethod, Object beanCodeGen) throws MojoExecutionException, MojoFailureException {
         try {
             return (Integer) processMethod.invoke(beanCodeGen);
@@ -299,6 +294,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
         }
     }
 
+    // invokes the builder
     @SuppressWarnings("unchecked")
     private List<File> invokeBuilderListChanges(Method processMethod, Object beanCodeGen) throws MojoExecutionException, MojoFailureException {
         try {
@@ -312,6 +308,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
         }
     }
 
+    // handles failure in reflection
     private MojoFailureException handleFailure(InvocationTargetException ex) throws MojoFailureException {
         String msg = ex.getCause().getMessage();
         File file = new File(getSourceDir());
@@ -353,11 +350,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
         return new MojoFailureException("Error while running Joda-Beans tool: " + msg, ex.getCause());
     }
 
-    /**
-     * Obtains the classloader from a set of file paths.
-     * 
-     * @return the classloader, not null
-     */
+    // obtains the classloader from a set of file paths
     private URLClassLoader obtainClassLoader() throws MojoExecutionException {
         logDebug("Finding joda-beans in classpath");
         List<String> compileClasspath = obtainClasspath();
@@ -377,12 +370,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
         return new URLClassLoader(classpathUrls, AbstractJodaBeansMojo.class.getClassLoader());
     }
 
-    /**
-     * Obtains the resolved classpath of dependencies.
-     * 
-     * @return the classpath, not null
-     * @throws MojoExecutionException
-     */
+    // obtains the resolved classpath of dependencies
     private List<String> obtainClasspath() throws MojoExecutionException {
         try {
             return project.getCompileClasspathElements();

--- a/src/main/java/org/joda/beans/maven/JodaBeansGenerateMojo.java
+++ b/src/main/java/org/joda/beans/maven/JodaBeansGenerateMojo.java
@@ -19,14 +19,19 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Maven plugin for generating Joda-Beans.
- * 
- * @goal generate
- * @phase process-sources
- * @requiresDependencyResolution compile
  */
+@Mojo(name = "generate",
+        defaultPhase = LifecyclePhase.PROCESS_SOURCES,
+        requiresDependencyResolution = ResolutionScope.COMPILE,
+        threadSafe = true)
+@Execute(goal = "generate", phase = LifecyclePhase.PROCESS_SOURCES)
 public class JodaBeansGenerateMojo extends AbstractJodaBeansMojo {
 
     //-----------------------------------------------------------------------

--- a/src/main/java/org/joda/beans/maven/JodaBeansGenerateMojo.java
+++ b/src/main/java/org/joda/beans/maven/JodaBeansGenerateMojo.java
@@ -15,17 +15,10 @@
  */
 package org.joda.beans.maven;
 
-import java.io.File;
-import java.util.List;
-
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.codehaus.plexus.util.Scanner;
-import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
  * Maven plugin for generating Joda-Beans.
@@ -35,76 +28,6 @@ import org.sonatype.plexus.build.incremental.BuildContext;
         requiresDependencyResolution = ResolutionScope.COMPILE,
         threadSafe = true)
 @Execute(goal = "generate", phase = LifecyclePhase.PROCESS_SOURCES)
-public class JodaBeansGenerateMojo extends AbstractJodaBeansMojo {
-
-    private static final String[] EMPTY_STRING_ARRAY = new String[0];
-
-    //-----------------------------------------------------------------------
-    @Override
-    protected void runTool(
-            Class<?> toolClass,
-            List<String> argsList,
-            BuildContext buildContext) throws MojoExecutionException, MojoFailureException {
-
-        // only match java files that have changed according to the build context
-        // this avoids processing when there is nothing to do
-        String[] changedSourceFiles = findFiles(buildContext, getSourceDir());
-        String[] changedTestFiles = findFiles(buildContext, getTestSourceDir());
-        int sourceFilesChanged = changedSourceFiles.length;
-        int testFilesChanged = changedTestFiles.length;
-
-        // if nothing to do then exit
-        if (sourceFilesChanged == 0 && testFilesChanged == 0) {
-            logInfo("No files changed");
-            return;
-        }
-        logDebug("Files changed: main=" + sourceFilesChanged + ", test=" + testFilesChanged);
-
-        logInfo("Joda-Bean generator started, directory: " + getSourceDir() +
-                (getTestSourceDir().length() == 0 ? "" : ", test directory: " + getTestSourceDir()));
-
-        // invoke main source
-        int changedFileCount = 0;
-        if (sourceFilesChanged > 0) {
-            if (sourceFilesChanged == 1) {
-                File file = new File(getSourceDir(), changedSourceFiles[0]);
-                argsList.add(file.toString());
-                logDebug("Single file: " + argsList.get(argsList.size() - 1));
-                changedFileCount += runToolHandleChanges(toolClass, argsList, file.getParentFile(), new File(getClassesDir()));
-            } else {
-                argsList.add(getSourceDir());
-                logDebug("All files: " + argsList.get(argsList.size() - 1));
-                changedFileCount += runToolHandleChanges(toolClass, argsList, new File(getSourceDir()), new File(getClassesDir()));
-            }
-        }
-        // optionally invoke test source
-        if (testFilesChanged > 0) {
-            if (testFilesChanged == 1) {
-                File file = new File(getSourceDir(), changedTestFiles[0]);
-                argsList.set(argsList.size() - 1, file.toString());
-                logDebug("Single test file: " + argsList.get(argsList.size() - 1));
-                changedFileCount += runToolHandleChanges(toolClass, argsList, file.getParentFile(), new File(getTestClassesDir()));
-            } else {
-                argsList.set(argsList.size() - 1, getTestSourceDir());
-                logDebug("All test files: " + argsList.get(argsList.size() - 1));
-                changedFileCount += runToolHandleChanges(toolClass, argsList, new File(getTestSourceDir()), new File(getTestClassesDir()));
-            }
-        }
-
-        logInfo("Joda-Bean generator completed, " + changedFileCount + " changed files");
-    }
-
-    // find Java files
-    private String[] findFiles(BuildContext buildContext, String dirStr) {
-        File dir = new File(dirStr);
-        if (dirStr.isEmpty() || !dir.exists()) {
-            return EMPTY_STRING_ARRAY;
-        }
-        Scanner scanner = buildContext.newScanner(dir);
-        scanner.setIncludes(new String[] {"**/*.java"});
-        scanner.scan();
-        String[] changedSourceFiles = scanner.getIncludedFiles();
-        return changedSourceFiles;
-    }
+public class JodaBeansGenerateMojo extends AbstractJodaBeansGenerateMojo {
 
 }

--- a/src/main/java/org/joda/beans/maven/JodaBeansGenerateMojo.java
+++ b/src/main/java/org/joda/beans/maven/JodaBeansGenerateMojo.java
@@ -15,6 +15,7 @@
  */
 package org.joda.beans.maven;
 
+import java.io.File;
 import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -23,6 +24,8 @@ import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.codehaus.plexus.util.Scanner;
+import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
  * Maven plugin for generating Joda-Beans.
@@ -36,12 +39,66 @@ public class JodaBeansGenerateMojo extends AbstractJodaBeansMojo {
 
     //-----------------------------------------------------------------------
     @Override
-    protected int runTool(Class<?> toolClass, List<String> argsList) throws MojoExecutionException, MojoFailureException {
-        getLog().info("Joda-Bean generator started, directory: " + getSourceDir() +
+    protected void runTool(
+            Class<?> toolClass,
+            List<String> argsList,
+            BuildContext buildContext) throws MojoExecutionException, MojoFailureException {
+
+        // only match java files that have changed according to the build context
+        // this avoids processing when there is nothing to do
+        Scanner scanner = buildContext.newScanner(new File(getSourceDir()));
+        scanner.setIncludes(new String[] {"**/*.java"});
+        scanner.scan();
+        String[] changedSourceFiles = scanner.getIncludedFiles();
+        int sourceFilesChanged = changedSourceFiles == null ? 0 : changedSourceFiles.length;
+        int testFilesChanged = 0;
+        if (getTestSourceDir().length() > 0) {
+            Scanner testFilesScanner = buildContext.newScanner(new File(getTestSourceDir()));
+            testFilesScanner.setIncludes(new String[] {"**/*.java"});
+            testFilesScanner.scan();
+            String[] changedTestFiles = testFilesScanner.getIncludedFiles();
+            testFilesChanged = changedTestFiles == null ? 0 : changedTestFiles.length;
+        }
+
+        // if nothing to do then exit
+        if (sourceFilesChanged == 0 && testFilesChanged == 0) {
+            logInfo("No files changed");
+            return;
+        }
+        logDebug("Files changed: main=" + sourceFilesChanged + ", test=" + testFilesChanged);
+
+        logInfo("Joda-Bean generator started, directory: " + getSourceDir() +
                         (getTestSourceDir().length() == 0 ? "" : ", test directory:" + getTestSourceDir()));
-        int changes = super.runTool(toolClass, argsList);
-        getLog().info("Joda-Bean generator completed, " + changes + " changed files");
-        return changes;
+
+        // invoke main source
+        int changedFileCount = 0;
+        if (sourceFilesChanged > 0) {
+            if (sourceFilesChanged == 1) {
+                File file = new File(getSourceDir(), changedSourceFiles[0]);
+                argsList.add(file.toString());
+                logDebug("Single file: " + argsList.get(argsList.size() - 1));
+                changedFileCount += runToolHandleChanges(toolClass, argsList, file.getParentFile(), new File(getClassesDir()));
+            } else {
+                argsList.add(getSourceDir());
+                logDebug("All files: " + argsList.get(argsList.size() - 1));
+                changedFileCount += runToolHandleChanges(toolClass, argsList, new File(getSourceDir()), new File(getClassesDir()));
+            }
+        }
+        // optionally invoke test source
+        if (testFilesChanged > 0 && getTestSourceDir().length() > 0) {
+            if (sourceFilesChanged == 1) {
+                File file = new File(getSourceDir(), changedSourceFiles[0]);
+                argsList.set(argsList.size() - 1, file.toString());
+                logDebug("Single test file: " + argsList.get(argsList.size() - 1));
+                changedFileCount += runToolHandleChanges(toolClass, argsList, file.getParentFile(), new File(getTestClassesDir()));
+            } else {
+                argsList.set(argsList.size() - 1, getTestSourceDir());
+                logDebug("All test files: " + argsList.get(argsList.size() - 1));
+                changedFileCount += runToolHandleChanges(toolClass, argsList, new File(getTestSourceDir()), new File(getTestClassesDir()));
+            }
+        }
+
+        logInfo("Joda-Bean generator completed, " + changedFileCount + " changed files");
     }
 
 }

--- a/src/main/java/org/joda/beans/maven/JodaBeansGenerateNoResolveMojo.java
+++ b/src/main/java/org/joda/beans/maven/JodaBeansGenerateNoResolveMojo.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2013-present, Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.beans.maven;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.repository.RepositorySystem;
+
+/**
+ * Maven plugin for generating Joda-Beans without dependency resolution.
+ */
+@Mojo(name = "generate-no-resolve", defaultPhase = LifecyclePhase.PROCESS_SOURCES, threadSafe = true)
+@Execute(goal = "generate-no-resolve", phase = LifecyclePhase.PROCESS_SOURCES)
+public class JodaBeansGenerateNoResolveMojo extends AbstractJodaBeansGenerateMojo {
+
+    private static ClassLoader cached = null;
+
+    @Parameter(alias = "jodaBeansVersion", property = "joda.beans.version", defaultValue = "2.5.0", required = true)
+    private String jodaBeansVersion;
+
+    @Component
+    private RepositorySystem repoSystem;
+
+    @Parameter(defaultValue = "${project.remoteArtifactRepositories}", required = true, readonly = true)
+    private List<ArtifactRepository> remoteRepos;
+
+    @Parameter(defaultValue = "${localRepository}", readonly = true, required = true)
+    private ArtifactRepository localRepo;
+
+    @Override
+    synchronized ClassLoader obtainClassLoader() throws MojoExecutionException {
+        if (cached != null) {
+            return cached;
+        }
+        logInfo("Finding joda-beans for version " + jodaBeansVersion + " (override using property: joda.beans.version)");
+        ArtifactResolutionRequest request = new ArtifactResolutionRequest();
+        request.setResolveTransitively(true);
+        request.setLocalRepository(localRepo);
+        request.setRemoteRepositories(remoteRepos);
+        request.setArtifact(repoSystem.createArtifact("org.joda", "joda-beans", jodaBeansVersion, "compile", "jar"));
+        ArtifactResolutionResult result = repoSystem.resolve(request);
+        if (!result.isSuccess()) {
+            throw new MojoExecutionException("Unable to resolve org.joda:joda-beans:" + jodaBeansVersion);
+        }
+        List<URL> classpath = new ArrayList<URL>();
+        for (Artifact artifact : result.getArtifacts()) {
+            File file = new File(localRepo.getBasedir(), localRepo.pathOf(artifact));
+            try {
+                URL location = file.toURI().toURL();
+                classpath.add(location);
+                logDebug("at " + location);
+            } catch (MalformedURLException ex) {
+                throw new RuntimeException("Error interpreting classpath entry as URL: " + file, ex);
+            }
+        }
+        URL[] classpathUrls = classpath.toArray(new URL[classpath.size()]);
+        URLClassLoader classLoader = new URLClassLoader(classpathUrls, AbstractJodaBeansMojo.class.getClassLoader());
+        cached = classLoader;
+        return classLoader;
+    }
+
+}

--- a/src/main/java/org/joda/beans/maven/JodaBeansValidateMojo.java
+++ b/src/main/java/org/joda/beans/maven/JodaBeansValidateMojo.java
@@ -19,19 +19,23 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Maven plugin for validating that the generated Joda-Beans are up to date.
- * 
- * @goal validate
- * @phase process-sources
- * @requiresDependencyResolution compile
  */
+@Mojo(name = "validate",
+        defaultPhase = LifecyclePhase.PROCESS_SOURCES,
+        requiresDependencyResolution = ResolutionScope.COMPILE,
+        threadSafe = true)
+@Execute(goal = "validate", phase = LifecyclePhase.PROCESS_SOURCES)
 public class JodaBeansValidateMojo extends AbstractJodaBeansMojo {
 
-    /**
-     * @parameter alias="stopOnError" property="joda.beans.stopOnError"
-     */
+    @Parameter(alias = "stopOnError", property = "joda.beans.stopOnError", defaultValue = "true")
     private boolean stopOnError = true;
 
     //-----------------------------------------------------------------------

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -17,6 +17,19 @@
     <pluginExecution>
       <pluginExecutionFilter>
         <goals>
+          <goal>generate-no-resolve</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnIncremental>true</runOnIncremental>
+          <runOnConfiguration>false</runOnConfiguration>
+        </execute>
+      </action>
+    </pluginExecution>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
           <goal>validate</goal>
         </goals>
       </pluginExecutionFilter>


### PR DESCRIPTION
Make thread-safe
Use annotations
Avoid processing when nothing has changed
Provide a new goal `generate-no-resolve` for Eclipse (and potentially other use cases)