### PR TITLE
Log files requiring re-generation

### DIFF
--- a/src/main/java/org/joda/beans/maven/AbstractJodaBeansGenerateMojo.java
+++ b/src/main/java/org/joda/beans/maven/AbstractJodaBeansGenerateMojo.java
@@ -68,11 +68,11 @@ public abstract class AbstractJodaBeansGenerateMojo extends AbstractJodaBeansMoj
                 File file = new File(sourceDir, changedSourceFiles[0]);
                 args.add(file.toString());
                 logDebug("Single file: " + args.get(args.size() - 1));
-                changedFileCount += runToolHandleChanges(toolClass, args, sourceDir, classesDir);
+                changedFileCount += runToolHandleChanges(toolClass, args, sourceDir, classesDir).size();
             } else {
                 args.add(getSourceDir());
                 logDebug("All files: " + args.get(args.size() - 1));
-                changedFileCount += runToolHandleChanges(toolClass, args, sourceDir, classesDir);
+                changedFileCount += runToolHandleChanges(toolClass, args, sourceDir, classesDir).size();
             }
         }
         // optionally invoke test source
@@ -87,11 +87,11 @@ public abstract class AbstractJodaBeansGenerateMojo extends AbstractJodaBeansMoj
                 File file = new File(sourceDir, changedTestFiles[0]);
                 args.add(file.toString());
                 logDebug("Single test file: " + args.get(args.size() - 1));
-                changedFileCount += runToolHandleChanges(toolClass, args, sourceDir, classesDir);
+                changedFileCount += runToolHandleChanges(toolClass, args, sourceDir, classesDir).size();
             } else {
                 args.add(getTestSourceDir());
                 logDebug("All test files: " + args.get(args.size() - 1));
-                changedFileCount += runToolHandleChanges(toolClass, args, sourceDir, classesDir);
+                changedFileCount += runToolHandleChanges(toolClass, args, sourceDir, classesDir).size();
             }
         }
 

--- a/src/main/java/org/joda/beans/maven/AbstractJodaBeansMojo.java
+++ b/src/main/java/org/joda/beans/maven/AbstractJodaBeansMojo.java
@@ -196,7 +196,7 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
     }
 
     // actually run the tool using the specified args
-    int runToolHandleChanges(Class<?> toolClass, List<String> argsList, File baseDir, File classesDir)
+    List<File> runToolHandleChanges(Class<?> toolClass, List<String> argsList, File baseDir, File classesDir)
             throws MojoExecutionException, MojoFailureException {
         try {
             String baseStr = baseDir.getCanonicalPath();
@@ -238,12 +238,12 @@ public abstract class AbstractJodaBeansMojo extends AbstractMojo {
                 logDebug("Refreshed: " + fileStr);
                 buildContext.refresh(new File(fileStr));
             }
-            return changedFiles.size();
+            return changedFiles;
         } catch (IOException ex) {
             throw new MojoExecutionException("IO problem: " + ex.toString(), ex);
         } catch (MojoFailureException ex) {
             if (eclipse && buildContext.getValue(JODA_BEANS_MESSAGE_FILE) != null) {
-                return 0;  // avoid showing error in Eclipse pom that is reported in a file
+                return Collections.emptyList();  // avoid showing error in Eclipse pom that is reported in a file
             } else {
                 throw ex;
             }

--- a/src/main/java/org/joda/beans/maven/JodaBeansValidateMojo.java
+++ b/src/main/java/org/joda/beans/maven/JodaBeansValidateMojo.java
@@ -16,9 +16,9 @@
 package org.joda.beans.maven;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Execute;
@@ -72,7 +72,7 @@ public class JodaBeansValidateMojo extends AbstractJodaBeansMojo {
     private List<File> runTool(Class<?> toolClass, List<String> argsList) throws MojoExecutionException, MojoFailureException {
         // invoke main source
         argsList.add(getSourceDir());
-        List<File> changedFiles = Lists.newLinkedList();
+        List<File> changedFiles = new ArrayList<>();
 
         List<File> productionFilesChanged = runToolHandleChanges(toolClass, argsList, new File(getSourceDir()), new File(getClassesDir()));
         changedFiles.addAll(productionFilesChanged);


### PR DESCRIPTION
Have the JodaBeansValidateMojo log the files of the beans requiring re-generation when configured to stop on error to make it easy to see which files need re-generating.